### PR TITLE
Checkbox lazy props

### DIFF
--- a/elements/howto-checkbox/howto-checkbox.e2etest.js
+++ b/elements/howto-checkbox/howto-checkbox.e2etest.js
@@ -77,7 +77,7 @@ describe('howto-checkbox pre-upgrade', function() {
     return this.driver.get(`${this.address}/howto-checkbox_demo.html?nojs`);
   });
 
-  it('should upgrade attributes on upgrade',
+  it('should handle attributes set before upgrade',
     async function() {
       await this.driver.executeScript(_ =>
         window.expectedCheckbox = document.querySelector('howto-checkbox')
@@ -88,6 +88,25 @@ describe('howto-checkbox pre-upgrade', function() {
 
       await this.driver.executeScript(_ => _loadJavaScript());
       success = await this.driver.executeScript(_ =>
+        window.expectedCheckbox.checked === true &&
+        window.expectedCheckbox.getAttribute('aria-checked') === 'true'
+      );
+      expect(success).to.equal(true);
+    }
+  );
+
+  it('should handle instance properties set before upgrade',
+    async function() {
+      await this.driver.executeScript(_ =>
+        window.expectedCheckbox = document.querySelector('howto-checkbox')
+      );
+      await this.driver.executeScript(_ =>
+        window.expectedCheckbox.checked = true
+      );
+
+      await this.driver.executeScript(_ => _loadJavaScript());
+      success = await this.driver.executeScript(_ =>
+        window.expectedCheckbox.hasAttribute('checked') &&
         window.expectedCheckbox.getAttribute('aria-checked') === 'true'
       );
       expect(success).to.equal(true);

--- a/elements/howto-checkbox/howto-checkbox.e2etest.js
+++ b/elements/howto-checkbox/howto-checkbox.e2etest.js
@@ -1,3 +1,5 @@
+/* eslint max-len: ["off"] */
+
 const helper = require('../../tools/selenium-helper.js');
 const expect = require('chai').expect;
 const {Key, By} = require('selenium-webdriver');
@@ -87,6 +89,7 @@ describe('howto-checkbox pre-upgrade', function() {
       );
 
       await this.driver.executeScript(_ => _loadJavaScript());
+      await this.driver.executeScript(_ => customElements.whenDefined('howto-checkbox'));
       success = await this.driver.executeScript(_ =>
         window.expectedCheckbox.checked === true &&
         window.expectedCheckbox.getAttribute('aria-checked') === 'true'
@@ -105,6 +108,7 @@ describe('howto-checkbox pre-upgrade', function() {
       );
 
       await this.driver.executeScript(_ => _loadJavaScript());
+      await this.driver.executeScript(_ => customElements.whenDefined('howto-checkbox'));
       success = await this.driver.executeScript(_ =>
         window.expectedCheckbox.hasAttribute('checked') &&
         window.expectedCheckbox.getAttribute('aria-checked') === 'true'

--- a/elements/howto-checkbox/howto-checkbox.e2etest.js
+++ b/elements/howto-checkbox/howto-checkbox.e2etest.js
@@ -69,3 +69,28 @@ describe('howto-checkbox', function() {
     }
   );
 });
+
+describe('howto-checkbox pre-upgrade', function() {
+  let success;
+
+  beforeEach(function() {
+    return this.driver.get(`${this.address}/howto-checkbox_demo.html?nojs`);
+  });
+
+  it('should upgrade attributes on upgrade',
+    async function() {
+      await this.driver.executeScript(_ =>
+        window.expectedCheckbox = document.querySelector('howto-checkbox')
+      );
+      await this.driver.executeScript(_ =>
+        window.expectedCheckbox.setAttribute('checked', '')
+      );
+
+      await this.driver.executeScript(_ => _loadJavaScript());
+      success = await this.driver.executeScript(_ =>
+        window.expectedCheckbox.getAttribute('aria-checked') === 'true'
+      );
+      expect(success).to.equal(true);
+    }
+  );
+});

--- a/elements/howto-checkbox/howto-checkbox.js
+++ b/elements/howto-checkbox/howto-checkbox.js
@@ -35,8 +35,34 @@
       if (!this.hasAttribute('tabindex'))
         this.setAttribute('tabindex', 0);
 
+      // A user may set a property on an _instance_ of an element,
+      // before its prototype has been connected to this class.
+      // The `upgradeProperty` method will check for any instance properties
+      // and run them through the proper class setters.
+      this.upgradeProperty('checked');
+      this.upgradeProperty('disabled');
+
       this.addEventListener('keydown', this._onKeyDown);
       this.addEventListener('click', this._onClick);
+    }
+
+    /**
+     * Check if a property has an instance value. If so, copy the value, and
+     * delete the instance property so it doesn't shadow the class property
+     * setter. Finally, pass the value to the class property setter so it can
+     * trigger any side effects.
+     * This is to safe guard against cases where, for instance, a framework
+     * may have added the element to the page and set a value on one of its
+     * properties, but lazy loaded its definition. Without this guard, the
+     * upgraded element would miss that property and the instance property
+     * would prevent the class property setter from ever being called.
+     */
+    upgradeProperty(prop) {
+      if (this.hasOwnProperty(prop)) {
+        let value = this[prop];
+        delete this[prop];
+        this[prop] = value;
+      }
     }
 
     /**

--- a/site-resources/demo.tpl.html
+++ b/site-resources/demo.tpl.html
@@ -32,9 +32,7 @@
     // sending any message.
     window.addEventListener('message', sendSize);
 
-    // If there’s a `nojs` in the URL’s query string, don’t load the elements,
-    // somewhat emulating disabled JavaScript.
-    if (!document.location.search.includes('nojs')) {
+    window._loadJavaScript = _ => {
       const whenScriptsLoaded = [
         'scripts/custom-elements.min.js',
         '{{=it.title}}.js',
@@ -42,9 +40,15 @@
         chain.then(_ => loadScript(src)),
         Promise.resolve()
       );
-      whenScriptsLoaded
+      return whenScriptsLoaded
         .then(_ => customElements.whenDefined('{{=it.title}}'))
         .then(_ => sendSize());
+    };
+
+    // If there’s a `nojs` in the URL’s query string, don’t load the elements,
+    // somewhat emulating disabled JavaScript.
+    if (!document.location.search.includes('nojs')) {
+      _loadJavaScript();
     }
 
     // Hook up ResizeObserver for dynamic size adjustments


### PR DESCRIPTION
This is a branch of #45 so you can ignore most of the changes. The interesting bits are in [this commit](https://github.com/GoogleChrome/howto-components/commit/931effd5da4d4da80f47bedf80308de36c606045).

This is based on the pattern recommended by Scott Miles from the Polymer team. The idea is if an element's definition is lazy loaded, it can still recover if someone has set a property value on the unupgraded instance.

I'd like to write a test for this but I'm not quite sure how to do that with the current test setup. [Here's a jsbin that illustrates what I'd like to do](https://jsbin.com/malavet/edit?html,console,output).

