### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Travis CI Build status badge](https://travis-ci.org/GoogleChrome/howto-components.svg?branch=master)
 
-“HowTo: Components” (sometimes stylized as <HowTo> components) is a subsection on Web Fundamentals Architecture section, containing a collection of web components that implement common web UI patterns using modern web technologies like Custom Elements v1 and ESnext with a special focus on accessibility, performance and progressive enhancement. Their purpose is to be an educational resource. Users are supposed to read and learn from their implementations. They are explicitly **NOT** a UI library meant to be used in production.
+“HowTo: Components” is a subsection on Web Fundamentals Architecture section, containing a collection of web components that implement common web UI patterns using modern web technologies like Custom Elements v1 and ESnext with a special focus on accessibility, performance and progressive enhancement. Their purpose is to be an educational resource. Users are supposed to read and learn from their implementations. They are explicitly **NOT** a UI library meant to be used in production.
 
 
 ## Demos


### PR DESCRIPTION
"“HowTo: Components” **(sometimes stylized as components)** is a subsection on Web Fundamentals Architecture "

This statement was kind of confusing for me. I think the README is a bit more clear if we just cut it.