### PR TITLE
Add meta docs

### DIFF
--- a/build-webfundamentals.sh
+++ b/build-webfundamentals.sh
@@ -6,3 +6,5 @@ mkdir -p webfundamentals/src/content/en/fundamentals/architecture/howto-componen
 find docs -type d -name 'howto-*' | while read line; do cp -r $line/*.md webfundamentals/src/content/en/fundamentals/architecture/howto-components/; done
 cp docs/styles/main.devsite.css webfundamentals/src/content/en/fundamentals/architecture/howto-components/main.css
 cp -r docs/images webfundamentals/src/content/en/fundamentals/architecture/howto-components/
+cat site-resources/static-header.md overview.md | sed "s/{%DATE%}/$(date +%Y-%m-%d)/" > webfundamentals/src/content/en/fundamentals/architecture/howto-components/overview.md
+cat site-resources/static-header.md glossary.md | sed "s/{%DATE%}/$(date +%Y-%m-%d)/" > webfundamentals/src/content/en/fundamentals/architecture/howto-components/glossary.md

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,77 @@
+# Glossary {: .page-title }
+{% include "web/_shared/contributors/robdodson.html" %}
+{% include "web/_shared/contributors/surma.html" %}
+
+
+### Web Components
+
+Web components are a set of web platform APIs that allow you to create new
+custom, reusable, encapsulated HTML tags to use in web pages and web apps.
+Custom components and widgets build on the Web Component standards, will work
+across modern browsers, and can be used with any JavaScript library or framework
+that works with HTML. To learn more about Web Components [check out the guide on
+webcomponents.org](https://www.webcomponents.org/introduction).
+
+### Custom Element
+
+A Custom Element is a developer defined HTML tag. These elements are the
+foundation of Web Components and can be used to create any sort of UI. To learn
+more about Custom Elements [check out the guide on Web
+Fundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/customelements).
+
+### Shadow DOM
+
+Shadow DOM introduces scoped CSS and DOM to the web platform. It lets developers
+write encapsulated UI components which can be used in any application. To learn
+more about Shadow DOM [check out the guide on Web
+Fundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/shadowdom).
+
+### Lifecycle Callback
+
+Every Custom Element has a set of built-in lifecycle callbacks, or "reactions"
+that are called when the element is added/removed from the page, or has an
+attribute mutated. To learn more about Custom Element lifecycle callbacks [check
+out the guide on Web
+Fundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/customelements#reactions).
+
+### Mutation Observer
+
+Mutation Observers are a web platform API to detect and react to change to the
+DOM tree. If an element is observed by a MutationObserver, events like appending
+a new element or removing and existing one will trigger a function to execute.
+For more details, [checkout out the guide on
+WebFundamentals](https://developers.google.com/web/updates/2012/02/Detect-DOM-changes-with-Mutation-Observers).
+
+### Lazy Property
+
+It's possible to set a property on a Custom Element instance *before* its
+definition has been loaded. A "lazy property", is a property which will check to
+see if there is already an instance value when the Custom Element definition is
+loaded. If a value is found, that value will be used in the newly upgraded
+element.
+
+### Roving Tabindex
+
+The `tabindex` attribute adds an element to the focus order, making it reachable
+via the keyboard. Roving tabindex is a technique which involves updating the
+tabindex for a set of children so that one child is focusable while the others
+are not. This technique is often used to provide arrow key support to an element
+which contains focusable children (lists, menus, etc). To learn more about
+roving tabindex [check out the guide on Web
+Fundamentals](https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex#managing_focus_in_components).
+
+### FLIP
+
+FLIP is a technique to set up high-performance animations using CSS transforms.
+To avoid janking animations, start *and* end position are evaluated during the
+setup so that the animation doesn't have to do any expensive calculations. For a
+detailed introduction, [check out Paul Lewis' guide on his
+blog](https://aerotwist.com/blog/flip-your-animations/).
+
+### aria-activedescendant / Active Descendant
+
+Setting the active descendant of an element to another elements ID allows us to
+tell assistive technology that an element should be presented to the user as the
+referenced element when its parent actually has the focus. To learn more about
+aria-activedescendant [check out the guide on Web
+Fundamentals](https://developers.google.com/web/fundamentals/accessibility/semantics-aria/aria-labels-and-relationships#aria-activedescendant).

--- a/overview.md
+++ b/overview.md
@@ -46,19 +46,20 @@ explaining why that is.
 
 ### Maintainable code
 
-As `<HowTo>` is aimed to be read and function as a reference implementation, we
-spent extra time on writing readable and easily comprehensible code that is
-densely commented.
+As HowTo: Components is aimed to be read and function as a reference
+implementation, we spent extra time on writing readable and easily
+comprehensible code that is densely commented.
 
 ## Non-Goals
 
 ### Be a library / framework / toolkit
 
-`<HowTo>` components are not published on npm, bower or any other platform
+`<howto>` components are not published on npm, bower or any other platform
 because they are not meant to be used in production. For the sake of terse,
-readable code, we are using modern JavaScript APIs and are supporting a subset
-of modern browsers. The idea is that you, the reader, are able adapt the code to
-fit your own needs after reading these implementations.
+readable code, we are using modern JavaScript APIs and are supporting modern
+browsers which implement the Web Components standards. The idea is that you, the
+reader, are able adapt the code to fit your own needs after reading these
+implementations.
 
 ### Be backwards compatible
 
@@ -71,6 +72,6 @@ explore, and discuss best practices for building web UIs.
 
 We currently don't (and probably won't) implement **all* *components that can be
 found in the WAI ARIA Authoring Practices. However, re-using the principles used
-in other `<HowTo>` components should enable readers to implement any components
+in other `<howto>` components should enable readers to implement any components
 that are missing.
 

--- a/overview.md
+++ b/overview.md
@@ -1,0 +1,76 @@
+# HowTo: Components – Overview {: .page-title }
+{% include "web/_shared/contributors/ewagasperowicz.html" %}
+{% include "web/_shared/contributors/noms.html" %}
+{% include "web/_shared/contributors/robdodson.html" %}
+{% include "web/_shared/contributors/surma.html" %}
+
+
+"HowTo: Components" are a collection of web components that implement common UI
+patterns. The purpose of these implementations is to be an educational resource.
+You can read through the densely commented implementation of different
+components and hopefully learn from them. Note that they are explicitly **NOT**
+a UI library and should **NOT** be used in production.
+
+## Goals
+
+Our aim is to demonstrate best practices for writing robust components that are
+accessible, performant, maintainable, and easy to style. Each component is
+completely self-contained so it can serve as a reference implementation.
+
+### Accessibility
+
+The components closely follow the [WAI ARIA Authoring
+Practices](https://www.w3.org/TR/wai-aria-practices-1.1/), which is a guide to
+explain and show ARIA, the [Accessible Rich Internet Application
+standard](https://www.w3.org/TR/wai-aria-1.1/). If you are unfamiliar with ARIA,
+[check out our introduction on
+WebFundamentals](https://developers.google.com/web/fundamentals/accessibility/semantics-aria/).
+Each component links to the relevant section of the Authoring Practices. While
+not strictly necessary, we do recommend reading the section of the Authoring
+Practices before diving into the code.
+
+### Performance
+
+In web development the term "performance" can be applied to a multitude of
+things. In the context of `<howto>`, performance mostly refers to animations
+consistently running at 60fps, even on mobile devices.
+
+### Visual Flexibility
+
+As much as possible, components are not styled, except for layout or to indicate
+a selected or active state. This is to keep the implementation visually flexible
+and focused. By not spending time on decoration, we limit the code to only what
+is absolutely necessary to make the component function. If any style is required
+for the component to function, the style will be marked with a comment
+explaining why that is.
+
+### Maintainable code
+
+As `<HowTo>` is aimed to be read and function as a reference implementation, we
+spent extra time on writing readable and easily comprehensible code that is
+densely commented.
+
+## Non-Goals
+
+### Be a library / framework / toolkit
+
+`<HowTo>` components are not published on npm, bower or any other platform
+because they are not meant to be used in production. For the sake of terse,
+readable code, we are using modern JavaScript APIs and are supporting a subset
+of modern browsers. The idea is that you, the reader, are able adapt the code to
+fit your own needs after reading these implementations.
+
+### Be backwards compatible
+
+The code should not be relied on directly. We might, and very likely *will*,
+drastically change the implementation and API of any element if a better
+implementation is discovered. This is a living resource where we can share,
+explore, and discuss best practices for building web UIs.
+
+### Be complete
+
+We currently don't (and probably won't) implement **all* *components that can be
+found in the WAI ARIA Authoring Practices. However, re-using the principles used
+in other `<HowTo>` components should enable readers to implement any components
+that are missing.
+

--- a/site-resources/static-header.md
+++ b/site-resources/static-header.md
@@ -1,0 +1,6 @@
+project_path: /web/_project.yaml
+book_path: /web/fundamentals/_book.yaml
+description: "HowTo: Components"
+
+{# wf_updated_on: {%DATE%} #}
+{# wf_published_on: 2017-04-06 #}


### PR DESCRIPTION
These are the pages for “Overview” and “Glossary”. They are assembled to WebFun pages by the `build-webfundamentals.sh` script.

@robdodson Should be let tech writers take a stab at these already?