### PR TITLE
howto-toggle-button

### DIFF
--- a/elements/howto-toggle-button/README.md
+++ b/elements/howto-toggle-button/README.md
@@ -1,0 +1,32 @@
+## Summary {: #summary }
+
+A `<howto-toggle-button>` represents a boolean option in a form. The most common type
+of toggle button is a dual-type which allows the user to toggle between two
+choices -- pressed and not pressed.
+
+The element attempts to self apply the attributes `role="button"` and
+`tabindex="0"` when it is first created. The `role` attribute helps assistive
+technology like a screen reader tell the user what kind of control this is.
+The `tabindex` attribute opts the element into the tab order, making it keyboard
+focusable and operable. To learn more about these two topics, check out
+[What can ARIA do?][what-aria] and [Using tabindex][using-tabindex].
+
+When the toggle button is pressed, it adds a `pressed` boolean attribute, and sets
+a corresponding `pressed` property to `true`. In addition, the element sets an
+`aria-pressed` attribute to either `"true"` or `"false"`, depending on its
+state. Clicking on the toggle button with a mouse, space bar or enter key, toggles these
+pressed states.
+
+The toggle button also supports a `disabled` state. If either the `disabled` property
+is set to true or the `disabled` attribute is applied, the toggle button sets
+`aria-disabled="true"` and set `tabindex="-1"`.
+
+## Reference {: #reference }
+
+- [Toggle Button Pattern in ARIA Authoring Practices 1.1][toggle-button-pattern]
+- [What can ARIA Do?][what-aria]
+- [Using tabindex][using-tabindex]
+
+[toggle-button-pattern]: https://www.w3.org/TR/wai-aria-practices-1.1/#button
+[what-aria]: https://developers.google.com/web/fundamentals/accessibility/semantics-aria/#what_can_aria_do
+[using-tabindex]: https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex

--- a/elements/howto-toggle-button/README.md
+++ b/elements/howto-toggle-button/README.md
@@ -19,7 +19,7 @@ pressed states.
 
 The toggle button also supports a `disabled` state. If either the `disabled` property
 is set to true or the `disabled` attribute is applied, the toggle button sets
-`aria-disabled="true"` and set `tabindex="-1"`.
+`aria-disabled="true"` and removes the `tabindex` attribute.
 
 ## Reference {: #reference }
 

--- a/elements/howto-toggle-button/demo.html
+++ b/elements/howto-toggle-button/demo.html
@@ -1,0 +1,14 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<howto-toggle-button>Press me</howto-toggle-button>

--- a/elements/howto-toggle-button/demo.html
+++ b/elements/howto-toggle-button/demo.html
@@ -10,5 +10,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<style>
+  howto-toggle-button {
+    background-color: #eee;  
+    padding: 3px;
+    cursor: default;
+    user-select: none;
+    border: 1px solid #333;
+    border-radius: 3px;
+    transition: background-color .2s ease;
+  }
+
+  howto-toggle-button[pressed],
+  howto-toggle-button:not([disabled]):active {
+    background-color: #999;
+  }
+
+  howto-toggle-button[disabled] {
+    opacity: 0.35;
+  }
+</style>
 
 <howto-toggle-button>Press me</howto-toggle-button>

--- a/elements/howto-toggle-button/howto-toggle-button.e2etest.js
+++ b/elements/howto-toggle-button/howto-toggle-button.e2etest.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint max-len: ["off"] */
+
+const helper = require('../../tools/selenium-helper.js');
+const expect = require('chai').expect;
+const {Key, By} = require('selenium-webdriver');
+
+describe('howto-toggle-button', function() {
+  let success;
+
+  const findToggleButton = _ => {
+    window.expectedToggleButton = document.querySelector('[role=button]');
+  };
+
+  const isUnpressed = _ => {
+    let isAriaUnpressed =
+      !window.expectedToggleButton.hasAttribute('aria-pressed') ||
+      window.expectedToggleButton.getAttribute('aria-pressed') === 'false';
+    return isAriaUnpressed && window.expectedToggleButton.pressed === false;
+  };
+
+  const isPressed = _ => {
+    let isAriaPressed = window.expectedToggleButton.getAttribute('aria-pressed') === 'true';
+    return isAriaPressed && window.expectedToggleButton.pressed === true;
+  };
+
+  beforeEach(function() {
+    return this.driver.get(`${this.address}/howto-toggle-button/demo.html`)
+      .then(_ => helper.waitForElement(this.driver, 'howto-toggle-button'));
+  });
+
+  it('should check the toggle button on [space]', async function() {
+    await this.driver.executeScript(findToggleButton);
+    success = await helper.pressKeyUntil(this.driver, Key.TAB, _ => document.activeElement === window.expectedToggleButton);
+    expect(success).to.be.true;
+    success = await this.driver.executeScript(isUnpressed);
+    expect(success).to.be.true;
+    await this.driver.actions().sendKeys(Key.SPACE).perform();
+    success = await this.driver.executeScript(isPressed);
+    expect(success).to.be.true;
+  });
+
+  it('should check the toggle button on [enter]', async function() {
+    await this.driver.executeScript(findToggleButton);
+    success = await helper.pressKeyUntil(this.driver, Key.TAB, _ => document.activeElement === window.expectedToggleButton);
+    expect(success).to.be.true;
+    success = await this.driver.executeScript(isUnpressed);
+    expect(success).to.be.true;
+    await this.driver.actions().sendKeys(Key.ENTER).perform();
+    success = await this.driver.executeScript(isPressed);
+    expect(success).to.be.true;
+  });
+
+  it('should not be focusable when [disabled] is true', async function() {
+    await this.driver.executeScript(findToggleButton);
+    success = await helper.pressKeyUntil(this.driver, Key.TAB, _ => document.activeElement === window.expectedToggleButton);
+    expect(success).to.be.true;
+    success = await this.driver.executeScript(_ => {
+      window.expectedToggleButton.disabled = true;
+      return document.activeElement != window.expectedToggleButton;
+    });
+    expect(success).to.be.true;
+  });
+
+  it('should check the toggle button on click', async function() {
+    await this.driver.executeScript(findToggleButton);
+    success = await this.driver.executeScript(isUnpressed);
+    expect(success).to.be.true;
+    await this.driver.findElement(By.css('[role=button]')).click();
+    success = await this.driver.executeScript(isPressed);
+    expect(success).to.be.true;
+  });
+});
+
+describe('howto-toggle-button pre-upgrade', function() {
+  let success;
+
+  beforeEach(function() {
+    return this.driver.get(`${this.address}/howto-toggle-button/demo.html?nojs`);
+  });
+
+  it('should handle attributes set before upgrade', async function() {
+    await this.driver.executeScript(_ => window.expectedToggleButton = document.querySelector('howto-toggle-button'));
+    await this.driver.executeScript(_ => window.expectedToggleButton.setAttribute('pressed', ''));
+
+    await this.driver.executeScript(_ => _loadJavaScript());
+    await helper.waitForElement(this.driver, 'howto-toggle-button');
+    success = await this.driver.executeScript(_ =>
+      window.expectedToggleButton.pressed === true &&
+      window.expectedToggleButton.getAttribute('aria-pressed') === 'true'
+    );
+    expect(success).to.be.true;
+  });
+
+  it('should handle instance properties set before upgrade', async function() {
+    await this.driver.executeScript(_ => window.expectedToggleButton = document.querySelector('howto-toggle-button'));
+    await this.driver.executeScript(_ => window.expectedToggleButton.pressed = true);
+
+    await this.driver.executeScript(_ => _loadJavaScript());
+    await helper.waitForElement(this.driver, 'howto-toggle-button');
+    success = await this.driver.executeScript(_ =>
+      window.expectedToggleButton.hasAttribute('pressed') &&
+      window.expectedToggleButton.getAttribute('aria-pressed') === 'true'
+    );
+    expect(success).to.be.true;
+  });
+});

--- a/elements/howto-toggle-button/howto-toggle-button.js
+++ b/elements/howto-toggle-button/howto-toggle-button.js
@@ -30,24 +30,10 @@
   template.innerHTML = `
     <style>
       :host {
-        background-color: #eee;
         display: inline-block;
-        padding: 3px;
-        border: 1px solid #333;
-        border-radius: 3px;
-        cursor: default;
-        user-select: none;
-        transition: background-color .2s ease;
       }
       :host([hidden]) {
         display: none;
-      }
-      :host([pressed]),
-      :host(:not([disabled]):active) {
-        background-color: #999;
-      }
-      :host([disabled]) {
-        opacity: 0.35;
       }
     </style>
     <slot></slot>

--- a/elements/howto-toggle-button/howto-toggle-button.js
+++ b/elements/howto-toggle-button/howto-toggle-button.js
@@ -42,11 +42,11 @@
       :host([hidden]) {
         display: none;
       }
-      :host([aria-pressed="true"]),
-      :host(:not([aria-disabled="true"]):active) {
+      :host([pressed]),
+      :host(:not([disabled]):active) {
         background-color: #999;
       }
-      :host([aria-disabled="true"]) {
+      :host([disabled]) {
         opacity: 0.35;
       }
     </style>

--- a/elements/howto-toggle-button/howto-toggle-button.js
+++ b/elements/howto-toggle-button/howto-toggle-button.js
@@ -1,0 +1,233 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+(function() {
+  /**
+   * Define key codes to help with handling keyboard events.
+   */
+  const KEYCODE = {
+    SPACE: 32,
+    ENTER: 13,
+  };
+
+  /**
+   * Cloning contents from a &lt;template&gt; element is more performant
+   * than using innerHTML because it avoids addtional HTML parse costs.
+   */
+  const template = document.createElement('template');
+  template.innerHTML = `
+    <style>
+      :host {
+        background-color: #eee;
+        display: inline-block;
+        padding: 3px;
+        border: 1px solid #333;
+        border-radius: 3px;
+        cursor: default;
+        user-select: none;
+        transition: background-color .2s ease;
+      }
+      :host([hidden]) {
+        display: none;
+      }
+      :host([aria-pressed="true"]),
+      :host(:not([aria-disabled="true"]):active) {
+        background-color: #999;
+      }
+      :host([aria-disabled="true"]) {
+        opacity: 0.35;
+      }
+    </style>
+    <slot></slot>
+  `;
+
+  // HIDE
+  // ShadyCSS will rename classes as needed to ensure style scoping.
+  ShadyCSS.prepareTemplate(template, 'howto-toggle-button');
+  // /HIDE
+
+  class HowToToggleButton extends HTMLElement {
+    static get observedAttributes() {
+      return ['pressed', 'disabled'];
+    }
+
+    /**
+     * The element's constructor is run anytime a new instance is created.
+     * Instances are created either by parsing HTML, calling
+     * document.createElement('howto-toggle-button'), or calling new HowToToggleButton();
+     * The construtor is a good place to create shadow DOM, though you should
+     * avoid touching any attributes or light DOM children as they may not
+     * be available yet.
+     */
+    constructor() {
+      super();
+      this.attachShadow({mode: 'open'});
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+
+    /**
+     * `connectedCallback()` fires when the element is inserted into the DOM.
+     * It's a good place to set the initial `role`, `tabindex`, internal state,
+     * and install event listeners.
+     */
+    connectedCallback() {
+      // HIDE
+      // Shim Shadow DOM styles. This needs to be run in `connectedCallback()`
+      // because if you shim Custom Properties (CSS variables) the element
+      // will need access to its parent node.
+      ShadyCSS.styleElement(this);
+      // /HIDE
+
+      if (!this.hasAttribute('role'))
+        this.setAttribute('role', 'button');
+      if (!this.hasAttribute('tabindex'))
+        this.setAttribute('tabindex', 0);
+
+      // A user may set a property on an _instance_ of an element,
+      // before its prototype has been connected to this class.
+      // The `_upgradeProperty()` method will check for any instance properties
+      // and run them through the proper class setters.
+      // See the [lazy properites](/web/fundamentals/architecture/building-components/best-practices#lazy-properties)
+      // section for more details.
+      this._upgradeProperty('pressed');
+      this._upgradeProperty('disabled');
+
+      this.addEventListener('keydown', this._onKeyDown);
+      this.addEventListener('click', this._onClick);
+    }
+
+    _upgradeProperty(prop) {
+      if (this.hasOwnProperty(prop)) {
+        let value = this[prop];
+        delete this[prop];
+        this[prop] = value;
+      }
+    }
+
+    /**
+     * `disconnectedCallback()` fires when the element is removed from the DOM.
+     * It's a good place to do clean up work like releasing references and
+     * removing event listeners.
+     */
+    disconnectedCallback() {
+      this.removeEventListener('keydown', this._onKeyDown);
+      this.removeEventListener('click', this._onClick);
+    }
+
+    /**
+     * Properties and their corresponding attributes should mirror one another.
+     * The property setter for `pressed` handles truthy/falsy values and
+     * reflects those to the state of the attribute. See the [avoid
+     * reentrancy](/web/fundamentals/architecture/building-components/best-practices#avoid-reentrancy)
+     * section for more details.
+     */
+    set pressed(value) {
+      const isPressed = Boolean(value);
+      if (isPressed)
+        this.setAttribute('pressed', '');
+      else
+        this.removeAttribute('pressed');
+    }
+
+    get pressed() {
+      return this.hasAttribute('pressed');
+    }
+
+    set disabled(value) {
+      const isDisabled = Boolean(value);
+      if (isDisabled)
+        this.setAttribute('disabled', '');
+      else
+        this.removeAttribute('disabled');
+    }
+
+    get disabled() {
+      return this.hasAttribute('disabled');
+    }
+
+    /**
+     * `attributeChangedCallback()` is called when any of the attributes in the
+     * `observedAttributes` array are changed. It's a good place to handle
+     * side effects, like setting ARIA attributes.
+     */
+    attributeChangedCallback(name, oldValue, newValue) {
+      const hasValue = newValue !== null;
+      switch (name) {
+        case 'pressed':
+          this.setAttribute('aria-pressed', hasValue);
+          break;
+        case 'disabled':
+          this.setAttribute('aria-disabled', hasValue);
+          // The `tabindex` attribute does not provide a way to fully remove
+          // focusability from an element.
+          // Elements with `tabindex=-1` can still be focused with
+          // a mouse or by calling `focus()`.
+          // To make sure an element is disabled and not focusable, remove the
+          // `tabindex` attribute.
+          if (hasValue) {
+            this.removeAttribute('tabindex');
+            // If the focus is currently on this element, unfocus it by
+            // calling the `HTMLElement.blur()` method.
+            this.blur();
+          } else {
+            this.setAttribute('tabindex', '0');
+          }
+          break;
+      }
+    }
+
+    _onKeyDown(event) {
+      // Don’t handle modifier shortcuts typically used by assistive technology.
+      if (event.altKey)
+        return;
+
+      switch (event.keyCode) {
+        case KEYCODE.SPACE:
+        case KEYCODE.ENTER:
+          event.preventDefault();
+          this._togglePressed();
+          break;
+        // Any other key press is ignored and passed back to the browser.
+        default:
+          return;
+      }
+    }
+
+    _onClick(event) {
+      this._togglePressed();
+    }
+
+    /**
+     * `_togglePressed()` calls the `pressed` setter and flips its state.
+     * Because `_togglePressed()` is only caused by a user action, it will
+     * also dispatch a change event.
+     */
+    _togglePressed() {
+      if (this.disabled)
+        return;
+      this.pressed = !this.pressed;
+      this.dispatchEvent(new CustomEvent('change', {
+        detail: {
+          pressed: this.pressed,
+        },
+        bubbles: true,
+      }));
+    }
+  }
+
+  window.customElements.define('howto-toggle-button', HowToToggleButton);
+})();
+
+

--- a/elements/howto-toggle-button/howto-toggle-button.unittest.js
+++ b/elements/howto-toggle-button/howto-toggle-button.unittest.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint max-len: ["off"] */
+
+(function() {
+  const expect = chai.expect;
+
+  describe('howto-toggle-button', function() {
+    before(howtoComponents.before());
+    after(howtoComponents.after());
+    beforeEach(function() {
+      this.container.innerHTML = `<howto-toggle-button>Press me</howto-toggle-button>`;
+      return howtoComponents.waitForElement('howto-toggle-button')
+        .then(_ => {
+          this.togglebutton = this.container.querySelector('howto-toggle-button');
+        });
+    });
+
+    it('should add a [role] to the togglebutton', function() {
+      expect(this.togglebutton.getAttribute('role')).to.equal('button');
+    });
+
+    it('should add a [tabindex] to the togglebutton', function() {
+      expect(this.togglebutton.getAttribute('tabindex')).to.equal('0');
+    });
+
+    describe('pressed', function() {
+      it('should toggle [pressed] and [aria-pressed] when calling ' +
+        '_togglePressed()', function() {
+          expect(this.togglebutton.pressed).to.be.false;
+          this.togglebutton._togglePressed();
+          expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('true');
+          expect(this.togglebutton.pressed).to.be.true;
+        });
+
+      it('should toggle [pressed] and [aria-pressed] when setting .pressed', function() {
+        expect(this.togglebutton.pressed).to.be.false;
+        this.togglebutton.pressed = true;
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('true');
+        expect(this.togglebutton.pressed).to.be.true;
+        this.togglebutton.pressed = false;
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('false');
+        expect(this.togglebutton.pressed).to.be.false;
+      });
+
+      it('should handle truthy/falsy values for .pressed', function() {
+        expect(this.togglebutton.pressed).to.be.false;
+        this.togglebutton.pressed = '0';
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('true');
+        expect(this.togglebutton.hasAttribute('pressed')).to.be.true;
+        expect(this.togglebutton.pressed).to.be.true;
+        this.togglebutton.pressed = undefined;
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('false');
+        expect(this.togglebutton.hasAttribute('pressed')).to.be.false;
+        expect(this.togglebutton.pressed).to.be.false;
+        this.togglebutton.pressed = 1;
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('true');
+        expect(this.togglebutton.hasAttribute('pressed')).to.be.true;
+        expect(this.togglebutton.pressed).to.be.true;
+      });
+
+      it('should toggle .pressed, [aria-pressed] when setting [pressed]', function() {
+        expect(this.togglebutton.hasAttribute('pressed')).to.be.false;
+        this.togglebutton.setAttribute('pressed', '');
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('true');
+        expect(this.togglebutton.pressed).to.be.true;
+        this.togglebutton.removeAttribute('pressed');
+        expect(this.togglebutton.getAttribute('aria-pressed')).to.equal('false');
+        expect(this.togglebutton.pressed).to.be.false;
+      });
+    });
+
+    describe('disabled', function() {
+      it('should toggle [disabled], [aria-disabled], and [tabindex] when setting .disabled', function() {
+        expect(this.togglebutton.disabled).to.be.false;
+        this.togglebutton.disabled = true;
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('true');
+        expect(this.togglebutton.hasAttribute('tabindex')).to.be.false;
+        expect(this.togglebutton.disabled).to.be.true;
+        this.togglebutton.disabled = false;
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('false');
+        expect(this.togglebutton.getAttribute('tabindex')).to.equal('0');
+        expect(this.togglebutton.disabled).to.be.false;
+      });
+
+      it('should handle truthy/falsy values for .disabled', function() {
+        expect(this.togglebutton.disabled).to.be.false;
+        this.togglebutton.disabled = '0';
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('true');
+        expect(this.togglebutton.hasAttribute('disabled')).to.be.true;
+        expect(this.togglebutton.disabled).to.be.true;
+        this.togglebutton.disabled = undefined;
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('false');
+        expect(this.togglebutton.hasAttribute('disabled')).to.be.false;
+        expect(this.togglebutton.disabled).to.be.false;
+        this.togglebutton.disabled = 1;
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('true');
+        expect(this.togglebutton.hasAttribute('disabled')).to.be.true;
+        expect(this.togglebutton.disabled).to.be.true;
+      });
+
+      it('should toggle .disabled, [aria-disabled] when setting [disabled]', function() {
+        expect(this.togglebutton.hasAttribute('disabled')).to.be.false;
+        this.togglebutton.setAttribute('disabled', '');
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('true');
+        expect(this.togglebutton.disabled).to.be.true;
+        this.togglebutton.removeAttribute('disabled');
+        expect(this.togglebutton.getAttribute('aria-disabled')).to.equal('false');
+        expect(this.togglebutton.disabled).to.be.false;
+      });
+    });
+  });
+})();


### PR DESCRIPTION
An implementation of a howto-toggle-button in compliance with the wai-aria-practices as stated here: https://www.w3.org/TR/wai-aria-practices-1.1/#button
Followed similar pattern as howto-checkbox and added corresponding unit as well as e2e tests.